### PR TITLE
fix user_can_verify_email test failing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,9 @@
     },
     "extra": {
         "laravel": {
-            "dont-discover": []
+            "dont-discover": [
+                "laravel/telescope"
+            ]
         }
     },
     "config": {

--- a/tests/Feature/Http/Controllers/Api/Auth/VerificationControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/Auth/VerificationControllerTest.php
@@ -25,11 +25,11 @@ class VerificationControllerTest extends TestCase
 
         $notification = new EmailVerification();
         $mail = $notification->toMail($user);
-        
+
         $transformVerificationUrl = str($mail->actionUrl)
             ->replace(
                 env('REACT_APP_URL', 'http://localhost:3000/auth'),
-                env('APP_URL', '/api')
+                env('APP_URL' . '/api', '/api')
             );
 
         $this->get($transformVerificationUrl)


### PR DESCRIPTION
## What's changed

- fix test failing
- add laravel-telescope to dont-discover